### PR TITLE
Add unit type and role to display

### DIFF
--- a/script/force-builder-data.js
+++ b/script/force-builder-data.js
@@ -1,3 +1,23 @@
+function getUnitTypeString(abbreviation) {
+    if (abbreviation.startsWith("BM")) {
+        return "BattleMech";
+    } else if (abbreviation.startsWith("IM")) {
+        return "IndustrialMech";
+    } else if (abbreviation.startsWith("PM")) {
+        return "ProtoMech";
+    } else if (abbreviation.startsWith("BA")) {
+        return "Battle Armor";
+    } else if (abbreviation.startsWith("CI")) {
+        return "Conventional Infantry";
+    } else if (abbreviation.startsWith("CV")) {
+        return "Combat Vehicle";
+    } else if (abbreviation.startsWith("LAM")) {
+        return "Land Air ′Mech";
+    } else if (abbreviation.startsWith("QV")) {
+        return "QuadVee";
+    } else return "Unknown";
+}
+
 function getWeaponName(weaponId) {
     const weapon = knownWeapons.find((x) => x.id == weaponId);
     return weapon ? weapon.name : weaponId;

--- a/script/force-builder.js
+++ b/script/force-builder.js
@@ -352,6 +352,8 @@ function addUnitRow(unit)
     $li.append($costsDiv);
 
     const $dataDiv = $("<div>", {class: "unit-costs"});
+    $dataDiv.append(`<span>Type: <span class='type'>${getUnitTypeString(unit.unitProps.unitType)}</span></span>`);
+    $dataDiv.append(`<span>Role: <span class='role'>${unit.unitProps.role}</span></span>`);
     $dataDiv.append(`<span>Rules Level: <span class='level'>${getRulesLevelString(getAdjustedRulesLevel(unit))}</span></span>`);
     $li.append($dataDiv);
 
@@ -1166,6 +1168,8 @@ function readyPrintContent() {
         $unitDiv.append($costsDiv);
 
         const $dataDiv = $("<div>", {class: "flex-row"});
+        $dataDiv.append(`<span class="flex-item"><b>Type:</b> ${getUnitTypeString(unit.unitProps.unitType)}</span>`);
+        $dataDiv.append(`<span class="flex-item"><b>Role:</b> ${unit.unitProps.role}</span>`);
         $dataDiv.append(`<span class="flex-item"><b>Rules Level:</b> ${getRulesLevelString(getAdjustedRulesLevel(unit))}</span>`);
         $unitDiv.append($dataDiv);
 


### PR DESCRIPTION
Add the unit type and role to their information block both in the UI and for printing