### PR TITLE
Add links to unit info in search results and force list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+unit-digest/

--- a/css/fwti.css
+++ b/css/fwti.css
@@ -47,6 +47,12 @@ button.network {
     float: right;
 }
 
+.search-results-list a {
+    padding: 0.3rem;
+    margin-right: 0.5rem;
+    float: right;
+}
+
 .search-bar {
     display: flex;
 }
@@ -165,6 +171,12 @@ button.network {
 
 .unit-entry-header .remove-button {
     float: right;
+}
+
+.unit-entry-header a {
+    float: right;
+    padding: 0.3rem;
+    margin-right: 0.5rem;
 }
 
 .subtle {

--- a/css/fwti.css
+++ b/css/fwti.css
@@ -173,6 +173,10 @@ button.network {
     float: right;
 }
 
+.unit-entry-header a {
+    float: right;
+}
+
 .subtle {
     color: var(--text-light);
 }

--- a/css/fwti.css
+++ b/css/fwti.css
@@ -175,6 +175,8 @@ button.network {
 
 .unit-entry-header a {
     float: right;
+    padding: 0.3rem;
+    margin-right: 0.5rem;
 }
 
 .subtle {

--- a/css/fwti.css
+++ b/css/fwti.css
@@ -47,6 +47,12 @@ button.network {
     float: right;
 }
 
+.search-results-list a {
+    padding: 0.3rem;
+    margin-right: 0.5rem;
+    float: right;
+}
+
 .search-bar {
     display: flex;
 }

--- a/css/fwti.css
+++ b/css/fwti.css
@@ -47,12 +47,6 @@ button.network {
     float: right;
 }
 
-.search-results-list a {
-    padding: 0.3rem;
-    margin-right: 0.5rem;
-    float: right;
-}
-
 .search-bar {
     display: flex;
 }
@@ -171,12 +165,6 @@ button.network {
 
 .unit-entry-header .remove-button {
     float: right;
-}
-
-.unit-entry-header a {
-    float: right;
-    padding: 0.3rem;
-    margin-right: 0.5rem;
 }
 
 .subtle {

--- a/script/force-builder.js
+++ b/script/force-builder.js
@@ -235,7 +235,7 @@ function showUnitList(list, moreAvailable, searching) {
         $("#search-results").append(`<li><em>No units found.</em></li>`);
     } else {
         list.forEach((unit) => {
-            $("#search-results").append(`<li><button title='Add unit to force' type='button' onclick='addUnitById("${unit.id}")'><span class="material-symbols-outlined">add</span></button><a href="#${unit.id}"><span class="material-symbols-outlined">info</span></a><span class="search-result">${unit.name}<span class="subtle"> - ${unit.bv.toLocaleString("en-us")}&nbsp;BV - ${getRulesLevelString(unit.level)}</span></span></li>`);
+            $("#search-results").append(`<li><button title='Add unit to force' type='button' onclick='addUnitById("${unit.id}")'><span class="material-symbols-outlined">add</span></button><a target="_blank" href="./unit-digest/${unit.id}.htm"><span class="material-symbols-outlined">info</span></a><span class="search-result">${unit.name}<span class="subtle"> - ${unit.bv.toLocaleString("en-us")}&nbsp;BV - ${getRulesLevelString(unit.level)}</span></span></li>`);
         });
         if (moreAvailable) {
             if (searchResumeToken) {
@@ -350,6 +350,7 @@ function addUnitRow(unit)
     
     const $headerRow = $("<div>", {class: "unit-entry-header"});
     $headerRow.append("<button class='remove-button' type='button' title='Remove unit from force' onclick='removeUnit(" + unit.id + ")'><span class='material-symbols-outlined'>delete</span></button>");
+    $headerRow.append(`<a target="_blank" href="./unit-digest/${unit.unitProps.id}.htm"><span class="material-symbols-outlined">info</span></a>`);
     $headerRow.append(`<h4>${unit.unitProps.name}</h4>`);
     $li.append($headerRow);
 

--- a/script/force-builder.js
+++ b/script/force-builder.js
@@ -235,7 +235,7 @@ function showUnitList(list, moreAvailable, searching) {
         $("#search-results").append(`<li><em>No units found.</em></li>`);
     } else {
         list.forEach((unit) => {
-            $("#search-results").append(`<li><button title='Add unit to force' type='button' onclick='addUnitById("${unit.id}")'><span class="material-symbols-outlined">add</span></button><span class="search-result">${unit.name} <a target="_blank" href="./unit-digest/${unit.id}.htm"><span class="material-symbols-outlined">info</span></a><span class="subtle"> - ${unit.bv.toLocaleString("en-us")}&nbsp;BV - ${getRulesLevelString(unit.level)}</span></span></li>`);
+            $("#search-results").append(`<li><button title='Add unit to force' type='button' onclick='addUnitById("${unit.id}")'><span class="material-symbols-outlined">add</span></button><a target="_blank" href="./unit-digest/${unit.id}.htm"><span class="material-symbols-outlined">info</span></a><span class="search-result">${unit.name}<span class="subtle"> - ${unit.bv.toLocaleString("en-us")}&nbsp;BV - ${getRulesLevelString(unit.level)}</span></span></li>`);
         });
         if (moreAvailable) {
             if (searchResumeToken) {
@@ -350,7 +350,8 @@ function addUnitRow(unit)
     
     const $headerRow = $("<div>", {class: "unit-entry-header"});
     $headerRow.append("<button class='remove-button' type='button' title='Remove unit from force' onclick='removeUnit(" + unit.id + ")'><span class='material-symbols-outlined'>delete</span></button>");
-    $headerRow.append(`<h4>${unit.unitProps.name} <a target="_blank" href="./unit-digest/${unit.unitProps.id}.htm"><span class="material-symbols-outlined">info</span></a></h4>`);
+    $headerRow.append(`<a target="_blank" href="./unit-digest/${unit.unitProps.id}.htm"><span class="material-symbols-outlined">info</span></a>`);
+    $headerRow.append(`<h4>${unit.unitProps.name}</h4>`);
     $li.append($headerRow);
 
     const $costsDiv = $("<div>", {class: "unit-costs"});

--- a/script/force-builder.js
+++ b/script/force-builder.js
@@ -235,7 +235,7 @@ function showUnitList(list, moreAvailable, searching) {
         $("#search-results").append(`<li><em>No units found.</em></li>`);
     } else {
         list.forEach((unit) => {
-            $("#search-results").append(`<li><button title='Add unit to force' type='button' onclick='addUnitById("${unit.id}")'><span class="material-symbols-outlined">add</span></button><a target="_blank" href="./unit-digest/${unit.id}.htm"><span class="material-symbols-outlined">info</span></a><span class="search-result">${unit.name}<span class="subtle"> - ${unit.bv.toLocaleString("en-us")}&nbsp;BV - ${getRulesLevelString(unit.level)}</span></span></li>`);
+            $("#search-results").append(`<li><button title='Add unit to force' type='button' onclick='addUnitById("${unit.id}")'><span class="material-symbols-outlined">add</span></button><span class="search-result">${unit.name} <a target="_blank" href="./unit-digest/${unit.id}.htm"><span class="material-symbols-outlined">info</span></a><span class="subtle"> - ${unit.bv.toLocaleString("en-us")}&nbsp;BV - ${getRulesLevelString(unit.level)}</span></span></li>`);
         });
         if (moreAvailable) {
             if (searchResumeToken) {
@@ -350,8 +350,7 @@ function addUnitRow(unit)
     
     const $headerRow = $("<div>", {class: "unit-entry-header"});
     $headerRow.append("<button class='remove-button' type='button' title='Remove unit from force' onclick='removeUnit(" + unit.id + ")'><span class='material-symbols-outlined'>delete</span></button>");
-    $headerRow.append(`<a target="_blank" href="./unit-digest/${unit.unitProps.id}.htm"><span class="material-symbols-outlined">info</span></a>`);
-    $headerRow.append(`<h4>${unit.unitProps.name}</h4>`);
+    $headerRow.append(`<h4>${unit.unitProps.name} <a target="_blank" href="./unit-digest/${unit.unitProps.id}.htm"><span class="material-symbols-outlined">info</span></a></h4>`);
     $li.append($headerRow);
 
     const $costsDiv = $("<div>", {class: "unit-costs"});

--- a/script/force-builder.js
+++ b/script/force-builder.js
@@ -235,7 +235,7 @@ function showUnitList(list, moreAvailable, searching) {
         $("#search-results").append(`<li><em>No units found.</em></li>`);
     } else {
         list.forEach((unit) => {
-            $("#search-results").append(`<li><button title='Add unit to force' type='button' onclick='addUnitById("${unit.id}")'><span class="material-symbols-outlined">add</span></button><span class="search-result">${unit.name}<span class="subtle"> - ${unit.bv.toLocaleString("en-us")}&nbsp;BV - ${getRulesLevelString(unit.level)}</span></span></li>`);
+            $("#search-results").append(`<li><button title='Add unit to force' type='button' onclick='addUnitById("${unit.id}")'><span class="material-symbols-outlined">add</span></button><a href="#${unit.id}"><span class="material-symbols-outlined">info</span></a><span class="search-result">${unit.name}<span class="subtle"> - ${unit.bv.toLocaleString("en-us")}&nbsp;BV - ${getRulesLevelString(unit.level)}</span></span></li>`);
         });
         if (moreAvailable) {
             if (searchResumeToken) {


### PR DESCRIPTION
Add `i` links to a unit summary page in both search results and the current force list. The digest pages are hosted in the unit-digest repo to allow separate deployments from the rest of the site.