### PR TITLE
Update search era/faction when force era/faction adjusted

### DIFF
--- a/script/force-builder.js
+++ b/script/force-builder.js
@@ -2032,6 +2032,9 @@ function getCrewPositionName(unit, slot) {
 }
 
 function updateUnitAvailabilities() {
+    $("#search-era").val($("#force-era").val());
+    $("#search-faction").val($("#force-faction").val());
+
     force.forEach((unit) => {
         updateUnitAvailability(unit);
     });


### PR DESCRIPTION
When the force era or faction selection is changed, update the search era and faction to match the force.