### PR TITLE
Ignore unique availability entries

### DIFF
--- a/script/force-builder.js
+++ b/script/force-builder.js
@@ -2096,7 +2096,9 @@ function updateMatchingAvailabilities() {
         let flattened = [];
         unit.unitProps.availability.forEach((era) => {
             era.factions.forEach((faction) => {
-                flattened.push({era: era.era, faction: faction});
+                if (faction != "unique") {
+                    flattened.push({era: era.era, faction: faction});
+                }
             });
         });
 


### PR DESCRIPTION
Remove "undefined" faction entries that show up in the availability tab for unique variants